### PR TITLE
input: qti-haptics: ensure valid pointer when calling kfree

### DIFF
--- a/drivers/input/misc/qti-haptics.c
+++ b/drivers/input/misc/qti-haptics.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (c) 2018-2020, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2018-2021, The Linux Foundation. All rights reserved.
  */
 
 #include <linux/debugfs.h>
@@ -1687,11 +1687,11 @@ static ssize_t brake_pattern_dbgfs_write(struct file *filep,
 {
 	struct qti_hap_effect *effect =
 		(struct qti_hap_effect *)filep->private_data;
-	char *kbuf, *token;
+	char *kbuf, *str, *token;
 	int rc = 0, i = 0, j;
 	u32 val;
 
-	kbuf = kmalloc(count + 1, GFP_KERNEL);
+	kbuf = kzalloc(count + 1, GFP_KERNEL);
 	if (!kbuf)
 		return -ENOMEM;
 
@@ -1703,8 +1703,8 @@ static ssize_t brake_pattern_dbgfs_write(struct file *filep,
 
 	kbuf[count] = '\0';
 	*ppos += count;
-
-	while ((token = strsep(&kbuf, " ")) != NULL) {
+	str = kbuf;
+	while ((token = strsep(&str, " ")) != NULL) {
 		rc = kstrtouint(token, 0, &val);
 		if (rc < 0) {
 			rc = -EINVAL;
@@ -1770,11 +1770,11 @@ static ssize_t pattern_dbgfs_write(struct file *filep,
 {
 	struct qti_hap_effect *effect =
 		(struct qti_hap_effect *)filep->private_data;
-	char *kbuf, *token;
+	char *kbuf, *str, *token;
 	int rc = 0, i = 0, j;
 	u32 val;
 
-	kbuf = kmalloc(count + 1, GFP_KERNEL);
+	kbuf = kzalloc(count + 1, GFP_KERNEL);
 	if (!kbuf)
 		return -ENOMEM;
 
@@ -1786,8 +1786,8 @@ static ssize_t pattern_dbgfs_write(struct file *filep,
 
 	kbuf[count] = '\0';
 	*ppos += count;
-
-	while ((token = strsep(&kbuf, " ")) != NULL) {
+	str = kbuf;
+	while ((token = strsep(&str, " ")) != NULL) {
 		rc = kstrtouint(token, 0, &val);
 		if (rc < 0) {
 			rc = -EINVAL;


### PR DESCRIPTION
In haptics pattern/brake debugfs file write operation functions,
strsep() is used iteratively to split the user-passed string into
tokens for setting parameters. However, strsep() modifies the pointer
passed and hence the same pointer cannot be used in kfree(). Fix this
by copying the pointer originally allocated by kmalloc() and use it
in kfree() as well. While at it, change kmalloc() to kzalloc().

Change-Id: I5a4c08db32683dfe5e4fefbce146fee1ac6cb88b
Signed-off-by: Fenglin Wu <fenglinw@codeaurora.org>